### PR TITLE
Added extern function to allow use from different SKSE plugins

### DIFF
--- a/src/Managers/ArousalManager.cpp
+++ b/src/Managers/ArousalManager.cpp
@@ -53,6 +53,30 @@ namespace ArousalManager
 		return SetArousal(actorRef, currentArousal + modValue);
 	}
 
+	float GetArousalExt(RE::Actor* actorRef)
+	{
+		if (!actorRef) {
+			return -2.f;
+		}
+		float newArousal = CalculateArousal(actorRef, 0.0f);
+		return newArousal;
+	}
+
+	float SetArousalExt(RE::Actor* actorRef, float value)
+	{
+		value = std::clamp(value, 0.0f, 100.f);
+		ArousalData::GetSingleton()->SetData(actorRef->formID, value);
+		return value;
+	}
+
+	float ModifyArousalExt(RE::Actor* actorRef, float modValue)
+	{
+		modValue *= PersistedData::ArousalMultiplierData::GetSingleton()->GetData(actorRef->formID, 1.f);
+		float currentArousal = GetArousalExt(actorRef);
+		auto loc_res = SetArousalExt(actorRef, currentArousal + modValue);
+		return loc_res;
+	}
+
 	float CalculateArousal(RE::Actor* actorRef, float gameHoursPassed)
 	{
 		float currentArousal = ArousalData::GetSingleton()->GetData(actorRef->formID, -2.f);

--- a/src/Managers/ArousalManager.h
+++ b/src/Managers/ArousalManager.h
@@ -9,4 +9,9 @@ namespace ArousalManager
 	float ModifyArousal(RE::Actor* actorRef, float value);
 
 	float CalculateArousal(RE::Actor* actorRef, float timePassed);
+
+	//modified functions to allow paralel proc from different plugin
+	extern "C" DLLEXPORT float GetArousalExt(RE::Actor* actorRef);
+	extern "C" DLLEXPORT float SetArousalExt(RE::Actor* actorRef, float value);
+	extern "C" DLLEXPORT float ModifyArousalExt(RE::Actor* actorRef, float value);
 }


### PR DESCRIPTION
Added new function which are using C extern and dll export, so they can be called dynamically from other SKSE plugins. Main reason why added it is that I myself need it for my orgasm system rework in Unforgiving Devices. This implementation works without much of an issue (only problem found is that the arousal widget bar is not updated). See how it is implemented on receiver plugin: [Usage](https://github.com/IHateMyKite/UnforgivingDevicesNative/blob/ab3180316023a12a3e8081388c9336e2904d928c/src/OrgasmSystem/OrgasmData.cpp#L16C83-L16C83) , [Setting up function](https://github.com/IHateMyKite/UnforgivingDevicesNative/blob/ab3180316023a12a3e8081388c9336e2904d928c/src/OrgasmSystem/OrgasmManager.cpp#L16-L27)

This is a only way I came up with. If you know of a way painful way, let me know.  Also, the extern functions doesn't contain some functionality

- time calculation, as I'm calling it on every frame which is basically too small to make difference
- arousal event, as again, calling it every frame would destroy the papyrus engine
